### PR TITLE
Ensure fe_cr package loads without external dependency

### DIFF
--- a/l10n_cr_edi/__init__.py
+++ b/l10n_cr_edi/__init__.py
@@ -1,1 +1,33 @@
+"""Odoo module bootstrap for the Costa Rican electronic invoicing addon."""
+
+from __future__ import annotations
+
+import os
+import sys
+
+
+def _ensure_fe_cr_on_path() -> None:
+    """Ensure the sibling ``fe_cr`` package is importable.
+
+    The Python helpers used by the addon live in a top-level ``fe_cr``
+    directory within the repository so that they can be re-used outside of
+    Odoo (for instance in unit tests).  When the addon is installed inside an
+    Odoo environment the module path only contains the ``l10n_cr_edi``
+    directory, which means the sibling package would not be discoverable by
+    default.  Adding the directory to ``sys.path`` makes the package available
+    without requiring a separate pip installation, avoiding spurious external
+    dependency errors during module installation.
+    """
+
+    module_dir = os.path.dirname(__file__)
+    package_dir = os.path.normpath(os.path.join(module_dir, os.pardir, "fe_cr"))
+
+    if package_dir not in sys.path and os.path.isdir(package_dir):
+        sys.path.insert(0, package_dir)
+
+
+_ensure_fe_cr_on_path()
+
 from . import models
+
+__all__ = ["models"]

--- a/l10n_cr_edi/__manifest__.py
+++ b/l10n_cr_edi/__manifest__.py
@@ -8,7 +8,7 @@
     "category": "Accounting/Localizations",
     "depends": ["account", "uom"],
     "external_dependencies": {
-        "python": ["fe_cr", "cryptography", "lxml", "signxml"],
+        "python": ["cryptography", "lxml", "signxml"],
     },
     "data": [
         "security/ir.model.access.csv",


### PR DESCRIPTION
## Summary
- remove the fe_cr library from the addon external dependency list since it ships with the repository
- add bootstrap logic so the addon exposes the sibling fe_cr package on sys.path during installation

## Testing
- not run (cryptography dependency is unavailable in the environment)


------
https://chatgpt.com/codex/tasks/task_e_68d673dd4888832680f392bf58519fda