### PR TITLE
Remove signxml dependency by implementing internal XML signer

### DIFF
--- a/fe_cr/signing.py
+++ b/fe_cr/signing.py
@@ -6,10 +6,10 @@ import base64
 from typing import Iterable, Optional
 
 from cryptography import x509
-from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import padding
 from cryptography.hazmat.primitives.serialization import pkcs12
 from lxml import etree
-from signxml import XMLSigner, methods
 
 
 class CertificateError(Exception):
@@ -33,14 +33,6 @@ def _load_pkcs12(p12_data: bytes, password: str | bytes | None):
 
 def _pem_bytes(cert: x509.Certificate) -> bytes:
     return cert.public_bytes(serialization.Encoding.PEM)
-
-
-def _serialize_private_key(private_key) -> bytes:
-    return private_key.private_bytes(
-        encoding=serialization.Encoding.PEM,
-        format=serialization.PrivateFormat.PKCS8,
-        encryption_algorithm=serialization.NoEncryption(),
-    )
 
 
 def sign_xml_with_p12(xml_content: bytes | str, p12_data: bytes | str, password: str | bytes | None) -> bytes:
@@ -81,25 +73,117 @@ def sign_xml_with_p12(xml_content: bytes | str, p12_data: bytes | str, password:
     except etree.XMLSyntaxError as exc:  # pragma: no cover - lxml mensaje explicativo
         raise ValueError("El XML proporcionado no es válido") from exc
 
-    signer = XMLSigner(
-        method=methods.enveloped,
-        signature_algorithm="rsa-sha256",
-        digest_algorithm="sha256",
-    )
-
-    key_pem = _serialize_private_key(private_key)
     cert_pem = _pem_bytes(certificate)
     ca_pems: Iterable[bytes] = (_pem_bytes(cert) for cert in extra_certs)
 
-    signed_root = signer.sign(
+    signed_root = _sign_enveloped(
         xml_tree,
-        key=key_pem,
-        cert=cert_pem,
+        private_key=private_key,
+        certificate_pem=cert_pem,
+        ca_pems=list(ca_pems),
         key_name=certificate.subject.rfc4514_string(),
-        ca_pem_list=list(ca_pems) or None,
     )
 
     return etree.tostring(signed_root, xml_declaration=True, encoding="utf-8")
+
+
+def _sign_enveloped(
+    xml_root: etree._Element,
+    *,
+    private_key,
+    certificate_pem: bytes,
+    ca_pems: list[bytes],
+    key_name: str,
+) -> etree._Element:
+    """Firmar ``xml_root`` usando un ``Signature`` enveloped RSA-SHA256.
+
+    Esta implementación reproduce el comportamiento requerido por el módulo
+    sin depender de :mod:`signxml`, evitando así la necesidad de instalar
+    dependencias externas en tiempo de ejecución.
+    """
+
+    ds_ns = "http://www.w3.org/2000/09/xmldsig#"
+    nsmap = {"ds": ds_ns}
+
+    signature_el = etree.Element(etree.QName(ds_ns, "Signature"), nsmap=nsmap)
+
+    signed_info = etree.SubElement(signature_el, etree.QName(ds_ns, "SignedInfo"))
+    etree.SubElement(
+        signed_info,
+        etree.QName(ds_ns, "CanonicalizationMethod"),
+        Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#",
+    )
+    etree.SubElement(
+        signed_info,
+        etree.QName(ds_ns, "SignatureMethod"),
+        Algorithm="http://www.w3.org/2001/04/xmldsig-more#rsa-sha256",
+    )
+
+    reference = etree.SubElement(signed_info, etree.QName(ds_ns, "Reference"), URI="")
+    transforms = etree.SubElement(reference, etree.QName(ds_ns, "Transforms"))
+    etree.SubElement(
+        transforms,
+        etree.QName(ds_ns, "Transform"),
+        Algorithm="http://www.w3.org/2000/09/xmldsig#enveloped-signature",
+    )
+    etree.SubElement(
+        transforms,
+        etree.QName(ds_ns, "Transform"),
+        Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#",
+    )
+
+    etree.SubElement(
+        reference,
+        etree.QName(ds_ns, "DigestMethod"),
+        Algorithm="http://www.w3.org/2001/04/xmlenc#sha256",
+    )
+
+    digest_value = etree.SubElement(reference, etree.QName(ds_ns, "DigestValue"))
+    digest_value.text = _digest_base64(xml_root)
+
+    signed_info_c14n = etree.tostring(
+        signed_info,
+        method="c14n",
+        exclusive=True,
+        with_comments=False,
+    )
+
+    signature_value = etree.SubElement(signature_el, etree.QName(ds_ns, "SignatureValue"))
+    signature_value.text = _signature_base64(signed_info_c14n, private_key)
+
+    key_info = etree.SubElement(signature_el, etree.QName(ds_ns, "KeyInfo"))
+    key_name_el = etree.SubElement(key_info, etree.QName(ds_ns, "KeyName"))
+    key_name_el.text = key_name
+
+    x509_data = etree.SubElement(key_info, etree.QName(ds_ns, "X509Data"))
+    etree.SubElement(x509_data, etree.QName(ds_ns, "X509Certificate")).text = _pem_body_b64(
+        certificate_pem
+    )
+    for ca_pem in ca_pems:
+        etree.SubElement(x509_data, etree.QName(ds_ns, "X509Certificate")).text = _pem_body_b64(
+            ca_pem
+        )
+
+    xml_root.append(signature_el)
+    return xml_root
+
+
+def _digest_base64(xml_root: etree._Element) -> str:
+    canonical = etree.tostring(xml_root, method="c14n", exclusive=True, with_comments=False)
+    digest = hashes.Hash(hashes.SHA256())
+    digest.update(canonical)
+    return base64.b64encode(digest.finalize()).decode("ascii")
+
+
+def _signature_base64(signed_info: bytes, private_key) -> str:
+    signature = private_key.sign(signed_info, padding.PKCS1v15(), hashes.SHA256())
+    return base64.b64encode(signature).decode("ascii")
+
+
+def _pem_body_b64(pem_bytes: bytes) -> str:
+    lines = pem_bytes.decode("ascii").splitlines()
+    body = [line for line in lines if not line.startswith("---") and line.strip()]
+    return "".join(body)
 
 
 __all__ = ["sign_xml_with_p12", "CertificateError"]

--- a/l10n_cr_edi/__init__.py
+++ b/l10n_cr_edi/__init__.py
@@ -1,1 +1,33 @@
+"""Odoo module bootstrap for the Costa Rican electronic invoicing addon."""
+
+from __future__ import annotations
+
+import os
+import sys
+
+
+def _ensure_fe_cr_on_path() -> None:
+    """Ensure the sibling ``fe_cr`` package is importable.
+
+    The Python helpers used by the addon live in a top-level ``fe_cr``
+    directory within the repository so that they can be re-used outside of
+    Odoo (for instance in unit tests).  When the addon is installed inside an
+    Odoo environment the module path only contains the ``l10n_cr_edi``
+    directory, which means the sibling package would not be discoverable by
+    default.  Adding the directory to ``sys.path`` makes the package available
+    without requiring a separate pip installation, avoiding spurious external
+    dependency errors during module installation.
+    """
+
+    module_dir = os.path.dirname(__file__)
+    package_dir = os.path.normpath(os.path.join(module_dir, os.pardir, "fe_cr"))
+
+    if package_dir not in sys.path and os.path.isdir(package_dir):
+        sys.path.insert(0, package_dir)
+
+
+_ensure_fe_cr_on_path()
+
 from . import models
+
+__all__ = ["models"]

--- a/l10n_cr_edi/__manifest__.py
+++ b/l10n_cr_edi/__manifest__.py
@@ -8,7 +8,7 @@
     "category": "Accounting/Localizations",
     "depends": ["account", "uom"],
     "external_dependencies": {
-        "python": ["fe_cr", "cryptography", "lxml", "signxml"],
+        "python": ["cryptography", "lxml"],
     },
     "data": [
         "security/ir.model.access.csv",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,6 @@ requires-python = ">=3.10"
 dependencies = [
     "cryptography>=41.0.0",
     "lxml>=4.9.0",
-    "signxml>=3.2.0",
 ]
 
 [project.urls]

--- a/tests/test_signing.py
+++ b/tests/test_signing.py
@@ -2,11 +2,14 @@ from __future__ import annotations
 
 from datetime import datetime, timedelta
 
+import base64
+
 from cryptography import x509
 from cryptography.hazmat.primitives import hashes, serialization
-from cryptography.hazmat.primitives.asymmetric import rsa
+from cryptography.hazmat.primitives.asymmetric import padding, rsa
 from cryptography.hazmat.primitives.serialization import pkcs12
-from signxml import XMLVerifier
+
+from lxml import etree
 
 from fe_cr.signing import sign_xml_with_p12
 
@@ -52,4 +55,58 @@ def test_sign_xml_with_p12_creates_valid_signature():
 
     assert b"Signature" in signed
 
-    XMLVerifier().verify(signed)
+    _assert_signature_valid(signed)
+
+
+def _assert_signature_valid(signed_xml: bytes) -> None:
+    root = etree.fromstring(signed_xml)
+    ds_ns = "http://www.w3.org/2000/09/xmldsig#"
+    signature_el = root.find(f".//{{{ds_ns}}}Signature")
+    assert signature_el is not None
+
+    signed_info = signature_el.find(f"{{{ds_ns}}}SignedInfo")
+    assert signed_info is not None
+
+    signed_info_c14n = etree.tostring(
+        signed_info,
+        method="c14n",
+        exclusive=True,
+        with_comments=False,
+    )
+
+    signature_value_el = signature_el.find(f"{{{ds_ns}}}SignatureValue")
+    assert signature_value_el is not None and signature_value_el.text
+    signature_value = base64.b64decode(signature_value_el.text)
+
+    cert_text = signature_el.findtext(f"{{{ds_ns}}}KeyInfo/{{{ds_ns}}}X509Data/{{{ds_ns}}}X509Certificate")
+    assert cert_text
+    cert = x509.load_der_x509_certificate(base64.b64decode(cert_text))
+
+    cert.public_key().verify(
+        signature_value,
+        signed_info_c14n,
+        padding.PKCS1v15(),
+        hashes.SHA256(),
+    )
+
+    digest_value_text = signature_el.findtext(
+        f"{{{ds_ns}}}SignedInfo/{{{ds_ns}}}Reference/{{{ds_ns}}}DigestValue"
+    )
+    assert digest_value_text
+    expected_digest = base64.b64decode(digest_value_text)
+
+    root_without_signature = etree.fromstring(signed_xml)
+    signature_to_remove = root_without_signature.find(f".//{{{ds_ns}}}Signature")
+    assert signature_to_remove is not None
+    signature_to_remove.getparent().remove(signature_to_remove)
+
+    canonical = etree.tostring(
+        root_without_signature,
+        method="c14n",
+        exclusive=True,
+        with_comments=False,
+    )
+
+    digest = hashes.Hash(hashes.SHA256())
+    digest.update(canonical)
+    assert digest.finalize() == expected_digest


### PR DESCRIPTION
## Summary
- implement an internal XMLDSig enveloped signer so the addon no longer relies on the external signxml package
- drop signxml from the addon manifest and project dependencies to keep installation self-contained
- update the signing test to validate the generated signatures using cryptography+lxml instead of signxml

## Testing
- pytest *(fails: ModuleNotFoundError: No module named 'cryptography')*

------
https://chatgpt.com/codex/tasks/task_e_68d673dd4888832680f392bf58519fda