### PR TITLE
Fix module path detection for fe_cr package

### DIFF
--- a/l10n_cr_edi/__init__.py
+++ b/l10n_cr_edi/__init__.py
@@ -14,16 +14,17 @@ def _ensure_fe_cr_on_path() -> None:
     Odoo (for instance in unit tests).  When the addon is installed inside an
     Odoo environment the module path only contains the ``l10n_cr_edi``
     directory, which means the sibling package would not be discoverable by
-    default.  Adding the directory to ``sys.path`` makes the package available
-    without requiring a separate pip installation, avoiding spurious external
-    dependency errors during module installation.
+    default.  Adding the shared repository root to ``sys.path`` makes the
+    package available without requiring a separate pip installation, avoiding
+    spurious external dependency errors during module installation.
     """
 
     module_dir = os.path.dirname(__file__)
-    package_dir = os.path.normpath(os.path.join(module_dir, os.pardir, "fe_cr"))
+    addons_root = os.path.normpath(os.path.join(module_dir, os.pardir))
+    package_dir = os.path.join(addons_root, "fe_cr")
 
-    if package_dir not in sys.path and os.path.isdir(package_dir):
-        sys.path.insert(0, package_dir)
+    if os.path.isdir(package_dir) and addons_root not in sys.path:
+        sys.path.insert(0, addons_root)
 
 
 _ensure_fe_cr_on_path()


### PR DESCRIPTION
## Summary
- ensure the addon adds the repository root to sys.path so the sibling fe_cr package can be imported
- update the explanatory docstring to describe the corrected path handling

## Testing
- python -m compileall l10n_cr_edi/__init__.py

------
https://chatgpt.com/codex/tasks/task_e_68d68d93b9c483269099cd352c0460a7