### PR TITLE
Fix invisible attributes in CR EDI invoice view

### DIFF
--- a/l10n_cr_edi/views/account_move_views.xml
+++ b/l10n_cr_edi/views/account_move_views.xml
@@ -13,15 +13,15 @@
                         <field name="cr_consecutive_number" readonly="1"/>
                         <field name="cr_activity_code"/>
                         <field name="cr_sale_condition"/>
-                        <field name="cr_credit_days" invisible="record.cr_sale_condition != '02'"/>
+                        <field name="cr_credit_days" attrs="{'invisible': [('cr_sale_condition', '!=', '02')]}"/>
                         <field name="cr_payment_methods" placeholder="01,04"/>
                     </group>
                     <group>
                         <field name="cr_document_ids" readonly="1" widget="one2many_list"/>
                     </group>
                     <footer>
-                        <button name="action_generate_cr_xml" type="object" string="Generar XML Hacienda" class="btn-primary" invisible="record.move_type not in ['out_invoice', 'out_refund']"/>
-                        <button name="action_send_cr_xml" type="object" string="Enviar XML a Hacienda" class="btn-secondary" invisible="record.move_type not in ['out_invoice', 'out_refund']"/>
+                        <button name="action_generate_cr_xml" type="object" string="Generar XML Hacienda" class="btn-primary" attrs="{'invisible': [('move_type', 'not in', ['out_invoice', 'out_refund'])]}"/>
+                        <button name="action_send_cr_xml" type="object" string="Enviar XML a Hacienda" class="btn-secondary" attrs="{'invisible': [('move_type', 'not in', ['out_invoice', 'out_refund'])]}"/>
                     </footer>
                 </page>
             </xpath>


### PR DESCRIPTION
## Summary
- replace invalid `invisible` expressions using `record` with proper `attrs` declarations in the CR EDI account move view
- ensure buttons and credit days field visibility rules no longer reference non-existent fields

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d691f990e08326af8a74304eeb33b8