### PR TITLE
Fix Costa Rica config xpath to match updated account settings layout

### DIFF
--- a/l10n_cr_edi/views/res_config_settings_views.xml
+++ b/l10n_cr_edi/views/res_config_settings_views.xml
@@ -5,7 +5,7 @@
         <field name="model">res.config.settings</field>
         <field name="inherit_id" ref="account.res_config_settings_view_form"/>
         <field name="arch" type="xml">
-            <xpath expr="//div[@id='account_settings']//div[@id='account_settings_invoicing']" position="inside">
+            <xpath expr="//div[@id='account_settings']" position="inside">
                 <div class="app_settings_block" data-string="Costa Rica" string="Costa Rica">
                     <h2>Factura electrónica Costa Rica</h2>
                     <div class="row mt16 o_setting_box">


### PR DESCRIPTION
## Summary
- update the inherited account settings view xpath to target the account settings container so the Costa Rica block loads with the latest layout

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d69ac3b7208326a9c40c027adf0c9d