### PR TITLE
Fix Costa Rica settings view xpath compatibility

### DIFF
--- a/l10n_cr_edi/views/res_config_settings_views.xml
+++ b/l10n_cr_edi/views/res_config_settings_views.xml
@@ -5,7 +5,7 @@
         <field name="model">res.config.settings</field>
         <field name="inherit_id" ref="account.res_config_settings_view_form"/>
         <field name="arch" type="xml">
-            <xpath expr="//div[@id='account_settings']" position="inside">
+            <xpath expr="//div[@id='account_settings'] | //div[@data-key='accounting']" position="inside">
                 <div class="app_settings_block" data-string="Costa Rica" string="Costa Rica">
                     <h2>Factura electrónica Costa Rica</h2>
                     <div class="row mt16 o_setting_box">


### PR DESCRIPTION
## Summary
- update the settings view extension to match both legacy and new account settings containers

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d6bb3464bc8326980923377c24c5cf