### PR TITLE
Adjust XPath for Costa Rica settings block in Odoo 17

### DIFF
--- a/l10n_cr_edi/views/res_config_settings_views.xml
+++ b/l10n_cr_edi/views/res_config_settings_views.xml
@@ -5,7 +5,7 @@
         <field name="model">res.config.settings</field>
         <field name="inherit_id" ref="account.res_config_settings_view_form"/>
         <field name="arch" type="xml">
-            <xpath expr="//div[@id='account_settings'] | //div[contains(@data-key, 'account')]" position="inside">
+            <xpath expr="//div[contains(@class, 'o_setting_container')][1]" position="inside">
                 <div class="app_settings_block" data-string="Costa Rica" string="Costa Rica">
                     <h2>Factura electrónica Costa Rica</h2>
                     <div class="row mt16 o_setting_box">


### PR DESCRIPTION
## Summary
- update the Costa Rica EDI settings view to insert the block into the current Odoo 17 container

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d6c5ec129083268fac491a92da7704