### PR TITLE
Fix settings view xpath selector for Odoo compatibility

### DIFF
--- a/l10n_cr_edi/views/res_config_settings_views.xml
+++ b/l10n_cr_edi/views/res_config_settings_views.xml
@@ -5,7 +5,7 @@
         <field name="model">res.config.settings</field>
         <field name="inherit_id" ref="account.res_config_settings_view_form"/>
         <field name="arch" type="xml">
-            <xpath expr="//div[contains(@class, 'o_setting_container')][1]" position="inside">
+            <xpath expr="//div[contains(@class, 'o_setting_container') or contains(@class, 'o_settings_container')][1]" position="inside">
                 <div class="app_settings_block" data-string="Costa Rica" string="Costa Rica">
                     <h2>Factura electrónica Costa Rica</h2>
                     <div class="row mt16 o_setting_box">


### PR DESCRIPTION
## Summary
- broaden the xpath selector in the Costa Rica settings view so it matches both legacy and new configuration container classes

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d6f0830a5c83269109bbbec2a1909f