### PR TITLE
Fix settings view xpath for Costa Rica configuration

### DIFF
--- a/l10n_cr_edi/views/res_config_settings_views.xml
+++ b/l10n_cr_edi/views/res_config_settings_views.xml
@@ -5,35 +5,39 @@
         <field name="model">res.config.settings</field>
         <field name="inherit_id" ref="account.res_config_settings_view_form"/>
         <field name="arch" type="xml">
-            <xpath expr="//div[contains(@class, 'o_setting_container') or contains(@class, 'o_settings_container')][1]" position="inside">
-                <div class="app_settings_block" data-string="Costa Rica" string="Costa Rica">
-                    <h2>Factura electrónica Costa Rica</h2>
-                    <div class="row mt16 o_setting_box">
-                        <div class="col-12 col-lg-6">
-                            <field name="cr_identification_type"/>
-                            <field name="cr_identification_number"/>
-                            <field name="cr_commercial_name"/>
-                            <field name="cr_activity_code"/>
-                        </div>
-                        <div class="col-12 col-lg-6">
-                            <field name="cr_phone_country_code"/>
-                            <field name="cr_phone_number"/>
-                            <field name="cr_email"/>
-                            <field name="cr_environment"/>
-                            <field name="cr_hacienda_username"/>
-                            <field name="cr_hacienda_password" password="True"/>
-                        </div>
-                    </div>
-                    <div class="row mt16 o_setting_box">
-                        <div class="col-12">
-                            <field name="cr_province"/>
-                            <field name="cr_canton"/>
-                            <field name="cr_district"/>
-                            <field name="cr_neighborhood"/>
-                            <field name="cr_address"/>
-                            <field name="cr_certificate_p12" filename="cr_certificate_filename"/>
-                            <field name="cr_certificate_filename" invisible="1"/>
-                            <field name="cr_certificate_password" password="True"/>
+            <xpath expr="//sheet" position="inside">
+                <div class="o_settings_container" data-key="fe_cr">
+                    <div class="settings">
+                        <div class="app_settings_block" data-string="Costa Rica" string="Costa Rica">
+                            <h2>Factura electrónica Costa Rica</h2>
+                            <div class="row mt16 o_setting_box">
+                                <div class="col-12 col-lg-6">
+                                    <field name="cr_identification_type"/>
+                                    <field name="cr_identification_number"/>
+                                    <field name="cr_commercial_name"/>
+                                    <field name="cr_activity_code"/>
+                                </div>
+                                <div class="col-12 col-lg-6">
+                                    <field name="cr_phone_country_code"/>
+                                    <field name="cr_phone_number"/>
+                                    <field name="cr_email"/>
+                                    <field name="cr_environment"/>
+                                    <field name="cr_hacienda_username"/>
+                                    <field name="cr_hacienda_password" password="True"/>
+                                </div>
+                            </div>
+                            <div class="row mt16 o_setting_box">
+                                <div class="col-12">
+                                    <field name="cr_province"/>
+                                    <field name="cr_canton"/>
+                                    <field name="cr_district"/>
+                                    <field name="cr_neighborhood"/>
+                                    <field name="cr_address"/>
+                                    <field name="cr_certificate_p12" filename="cr_certificate_filename"/>
+                                    <field name="cr_certificate_filename" invisible="1"/>
+                                    <field name="cr_certificate_password" password="True"/>
+                                </div>
+                            </div>
                         </div>
                     </div>
                 </div>


### PR DESCRIPTION
## Summary
- update the Costa Rican electronic invoice settings inheritance to target the sheet container so the block is always inserted

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d709c532388326a827e47dc9ef2427