### PR TITLE
Fix res config settings view xpath for Odoo 17

### DIFF
--- a/l10n_cr_edi/views/res_config_settings_views.xml
+++ b/l10n_cr_edi/views/res_config_settings_views.xml
@@ -5,7 +5,7 @@
         <field name="model">res.config.settings</field>
         <field name="inherit_id" ref="account.res_config_settings_view_form"/>
         <field name="arch" type="xml">
-            <xpath expr="//div[hasclass('o_setting_container') or hasclass('o_settings_container') or hasclass('settings')]" position="inside">
+            <xpath expr="//form" position="inside">
                 <div class="app_settings_block" data-key="fe_cr" data-string="Costa Rica" string="Costa Rica">
                     <h2>Factura electrónica Costa Rica</h2>
                     <div class="row mt16 o_setting_box">


### PR DESCRIPTION
## Summary
- update the res.config.settings inherited view to inject the Costa Rica section directly into the form so it loads on Odoo 17

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d71b4c134c83269408f7f0857a8423