### PR TITLE
Fix tax view xpath for description field

### DIFF
--- a/l10n_cr_edi/views/account_tax_views.xml
+++ b/l10n_cr_edi/views/account_tax_views.xml
@@ -5,7 +5,7 @@
         <field name="model">account.tax</field>
         <field name="inherit_id" ref="account.view_tax_form"/>
         <field name="arch" type="xml">
-            <xpath expr="//group[@name='description_group']/field[@name='description']" position="after">
+            <xpath expr="//field[@name='description']" position="after">
                 <field name="l10n_cr_tax_code"/>
                 <field name="l10n_cr_summary_group"/>
             </xpath>


### PR DESCRIPTION
## Summary
- relax the XPath in the Costa Rica tax form inheritance to target the description field without relying on the removed `description_group`

## Testing
- not run (XML-only change)


------
https://chatgpt.com/codex/tasks/task_e_68d7456abd148326ba71f121b4d97a18