### PR TITLE
Fix UoM form view inheritance ID

### DIFF
--- a/l10n_cr_edi/views/uom_uom_views.xml
+++ b/l10n_cr_edi/views/uom_uom_views.xml
@@ -3,7 +3,7 @@
     <record id="view_uom_form_inherit_fe_cr" model="ir.ui.view">
         <field name="name">uom.uom.form.fe.cr</field>
         <field name="model">uom.uom</field>
-        <field name="inherit_id" ref="uom.uom_view_form"/>
+        <field name="inherit_id" ref="uom.uom_uom_view_form"/>
         <field name="arch" type="xml">
             <xpath expr="//field[@name='category_id']" position="after">
                 <field name="l10n_cr_code"/>


### PR DESCRIPTION
## Summary
- Point the UoM form inheritance to the correct base view XML ID to avoid missing external ID errors during installation

## Testing
- Not run


------
https://chatgpt.com/codex/tasks/task_e_68d747dacd64832690f245bbf9253f1e