### PR TITLE
Fix electronic document list view definition

### DIFF
--- a/l10n_cr_edi/views/electronic_document_views.xml
+++ b/l10n_cr_edi/views/electronic_document_views.xml
@@ -4,13 +4,13 @@
         <field name="name">fe.cr.document.tree</field>
         <field name="model">fe.cr.document</field>
         <field name="arch" type="xml">
-            <tree string="Documentos electrónicos">
+            <list string="Documentos electrónicos">
                 <field name="name"/>
                 <field name="move_id"/>
                 <field name="state"/>
                 <field name="sent_date"/>
                 <field name="response_date"/>
-            </tree>
+            </list>
         </field>
     </record>
 


### PR DESCRIPTION
## Summary
- replace the invalid `<tree>` tag with `<list>` in the electronic document view definition

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d77822ac448326917693d9f2bd8c51