### PR TITLE
Refine electronic document form structure

### DIFF
--- a/l10n_cr_edi/views/electronic_document_views.xml
+++ b/l10n_cr_edi/views/electronic_document_views.xml
@@ -4,13 +4,13 @@
         <field name="name">fe.cr.document.tree</field>
         <field name="model">fe.cr.document</field>
         <field name="arch" type="xml">
-            <tree string="Documentos electrónicos">
+            <list string="Documentos electrónicos">
                 <field name="name"/>
                 <field name="move_id"/>
                 <field name="state"/>
                 <field name="sent_date"/>
                 <field name="response_date"/>
-            </tree>
+            </list>
         </field>
     </record>
 
@@ -19,11 +19,15 @@
         <field name="model">fe.cr.document</field>
         <field name="arch" type="xml">
             <form string="Documento electrónico">
+                <header>
+                    <field name="state"
+                           widget="statusbar"
+                           statusbar_visible="draft,generated,sent,accepted,rejected,error"/>
+                </header>
                 <sheet>
                     <group>
                         <field name="name"/>
                         <field name="move_id"/>
-                        <field name="state" widget="statusbar" statusbar_visible="draft,generated,sent,accepted,rejected,error"/>
                     </group>
                     <group>
                         <field name="xml_filename" readonly="1"/>


### PR DESCRIPTION
## Summary
- move the electronic document statusbar field to the form header to follow Odoo view structure guidelines
- keep the sheet layout focused on document metadata and related XML content

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d77822ac448326917693d9f2bd8c51