### PR TITLE
Add fe_cr external dependency

### DIFF
--- a/l10n_cr_edi/__manifest__.py
+++ b/l10n_cr_edi/__manifest__.py
@@ -8,7 +8,7 @@
     "category": "Accounting/Localizations",
     "depends": ["account", "uom"],
     "external_dependencies": {
-        "python": ["cryptography", "lxml"],
+        "python": ["cryptography", "lxml", "fe_cr"],
     },
     "data": [
         "security/ir.model.access.csv",


### PR DESCRIPTION
## Summary
- ensure the Odoo manifest declares the fe_cr package in external Python dependencies

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d8d033c194832680ad7b775c9716a6