### PR TITLE
Remove fe_cr external dependency declaration

### DIFF
--- a/l10n_cr_edi/__manifest__.py
+++ b/l10n_cr_edi/__manifest__.py
@@ -8,7 +8,7 @@
     "category": "Accounting/Localizations",
     "depends": ["account", "uom"],
     "external_dependencies": {
-        "python": ["cryptography", "lxml", "fe_cr"],
+        "python": ["cryptography", "lxml"],
     },
     "data": [
         "security/ir.model.access.csv",


### PR DESCRIPTION
## Summary
- stop declaring the bundled `fe_cr` helper package as an external Python dependency so the addon can install without pip metadata

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d8d265aab88326b7d5e95effef39ec