### PR TITLE
Handle FE attrs compatibility for Odoo 17

### DIFF
--- a/l10n_cr_edi/views/account_move_views.xml
+++ b/l10n_cr_edi/views/account_move_views.xml
@@ -7,21 +7,23 @@
         <field name="arch" type="xml">
             <xpath expr="//sheet/notebook/page[@name='invoice_tab']" position="after">
                 <page name="fe_cr" string="Factura electrónica CR">
+                    <field name="show_cr_credit_days" invisible="1"/>
+                    <field name="show_cr_xml_actions" invisible="1"/>
                     <group>
                         <field name="cr_electronic_state" readonly="1"/>
                         <field name="cr_invoice_key" readonly="1"/>
                         <field name="cr_consecutive_number" readonly="1"/>
                         <field name="cr_activity_code"/>
                         <field name="cr_sale_condition"/>
-                        <field name="cr_credit_days" attrs="{'invisible': [('cr_sale_condition', '!=', '02')]}"/>
+                        <field name="cr_credit_days" invisible="not record.show_cr_credit_days"/>
                         <field name="cr_payment_methods" placeholder="01,04"/>
                     </group>
                     <group>
                         <field name="cr_document_ids" readonly="1" widget="one2many_list"/>
                     </group>
                     <footer>
-                        <button name="action_generate_cr_xml" type="object" string="Generar XML Hacienda" class="btn-primary" attrs="{'invisible': [('move_type', 'not in', ('out_invoice', 'out_refund'))]}"/>
-                        <button name="action_send_cr_xml" type="object" string="Enviar XML a Hacienda" class="btn-secondary" attrs="{'invisible': [('move_type', 'not in', ('out_invoice', 'out_refund'))]}"/>
+                        <button name="action_generate_cr_xml" type="object" string="Generar XML Hacienda" class="btn-primary" invisible="not record.show_cr_xml_actions"/>
+                        <button name="action_send_cr_xml" type="object" string="Enviar XML a Hacienda" class="btn-secondary" invisible="not record.show_cr_xml_actions"/>
                     </footer>
                 </page>
             </xpath>


### PR DESCRIPTION
## Summary
- add helper compute fields on account moves to expose visibility flags for credit days and XML actions
- update the electronic invoicing tab to rely on the new fields instead of deprecated attrs/states modifiers

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d8d37f1cec83269ef3465a0dfef408