### PR TITLE
Fix visibility conditions for CR electronic invoice fields

### DIFF
--- a/l10n_cr_edi/views/account_move_views.xml
+++ b/l10n_cr_edi/views/account_move_views.xml
@@ -15,15 +15,15 @@
                         <field name="cr_consecutive_number" readonly="1"/>
                         <field name="cr_activity_code"/>
                         <field name="cr_sale_condition"/>
-                        <field name="cr_credit_days" invisible="not record.show_cr_credit_days"/>
+                        <field name="cr_credit_days" attrs="{'invisible': [('show_cr_credit_days', '=', False)]}"/>
                         <field name="cr_payment_methods" placeholder="01,04"/>
                     </group>
                     <group>
                         <field name="cr_document_ids" readonly="1" widget="one2many_list"/>
                     </group>
                     <footer>
-                        <button name="action_generate_cr_xml" type="object" string="Generar XML Hacienda" class="btn-primary" invisible="not record.show_cr_xml_actions"/>
-                        <button name="action_send_cr_xml" type="object" string="Enviar XML a Hacienda" class="btn-secondary" invisible="not record.show_cr_xml_actions"/>
+                        <button name="action_generate_cr_xml" type="object" string="Generar XML Hacienda" class="btn-primary" attrs="{'invisible': [('show_cr_xml_actions', '=', False)]}"/>
+                        <button name="action_send_cr_xml" type="object" string="Enviar XML a Hacienda" class="btn-secondary" attrs="{'invisible': [('show_cr_xml_actions', '=', False)]}"/>
                     </footer>
                 </page>
             </xpath>


### PR DESCRIPTION
## Summary
- replace the invalid `record`-based invisible expressions with standard `attrs` domains on the Costa Rica electronic invoicing fields and buttons

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d98ec93b888326aba8372097d1d420