### PR TITLE
Fix UoM form view xpath

### DIFF
--- a/l10n_cr_edi/views/uom_uom_views.xml
+++ b/l10n_cr_edi/views/uom_uom_views.xml
@@ -5,7 +5,7 @@
         <field name="model">uom.uom</field>
         <field name="inherit_id" ref="uom.uom.form"/>
         <field name="arch" type="xml">
-            <xpath expr="//field[@name='category_id']" position="after">
+            <xpath expr="//group/field[@name='name']" position="after">
                 <field name="l10n_cr_code"/>
             </xpath>
         </field>


### PR DESCRIPTION
## Summary
- adjust the UoM form view xpath to target the first group name field so the extension always matches

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68da2455ec348326902f98f7f6a3cc22