### PR TITLE
Fix xpath target in UoM form view for l10n CR code field

### DIFF
--- a/l10n_cr_edi/views/uom_uom_views.xml
+++ b/l10n_cr_edi/views/uom_uom_views.xml
@@ -5,7 +5,7 @@
         <field name="model">uom.uom</field>
         <field name="inherit_id" ref="uom.uom.form"/>
         <field name="arch" type="xml">
-            <xpath expr="//group/field[@name='name']" position="after">
+            <xpath expr="//field[@name='name'][ancestor::sheet]" position="after">
                 <field name="l10n_cr_code"/>
             </xpath>
         </field>


### PR DESCRIPTION
## Summary
- update the inherited uom form view to target the name field inside the sheet when inserting the Costa Rican code field

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68da28583c288326b4cdcb15e456a6eb