### PR TITLE
Fix UoM view inheritance references for Odoo 19

### DIFF
--- a/l10n_cr_edi/views/uom_uom_views.xml
+++ b/l10n_cr_edi/views/uom_uom_views.xml
@@ -3,7 +3,7 @@
     <record id="view_uom_form_inherit_fe_cr" model="ir.ui.view">
         <field name="name">uom.uom.form.fe.cr</field>
         <field name="model">uom.uom</field>
-        <field name="inherit_id" ref="uom.view_uom_form"/>
+        <field name="inherit_id" ref="uom.uom_view_form"/>
         <field name="arch" type="xml">
             <xpath expr="//sheet//group//field[@name='category_id']" position="after">
                 <field name="l10n_cr_code"/>
@@ -14,7 +14,7 @@
     <record id="view_uom_tree_inherit_fe_cr" model="ir.ui.view">
         <field name="name">uom.uom.list.fe.cr</field>
         <field name="model">uom.uom</field>
-        <field name="inherit_id" ref="uom.view_uom_tree"/>
+        <field name="inherit_id" ref="uom.uom_view_tree"/>
         <field name="arch" type="xml">
             <xpath expr="//tree//field[@name='name']" position="after">
                 <field name="l10n_cr_code"/>
@@ -25,7 +25,7 @@
     <record id="view_uom_search_inherit_fe_cr" model="ir.ui.view">
         <field name="name">uom.uom.view.search.fe.cr</field>
         <field name="model">uom.uom</field>
-        <field name="inherit_id" ref="uom.view_uom_search"/>
+        <field name="inherit_id" ref="uom.uom_view_search"/>
         <field name="arch" type="xml">
             <xpath expr="//search//field[@name='name']" position="after">
                 <field name="l10n_cr_code"/>


### PR DESCRIPTION
## Summary
- update the UoM view inheritance references to use the current XML IDs shipped with the `uom` module
- ensure the localization module can be installed without missing external ID errors

## Testing
- no automated tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68db60e118d48326b93101e0134c7820