### PR TITLE
Handle multiple possible UoM base view xml ids

### DIFF
--- a/l10n_cr_edi/views/uom_uom_views.xml
+++ b/l10n_cr_edi/views/uom_uom_views.xml
@@ -3,7 +3,10 @@
     <record id="view_uom_form_inherit_fe_cr" model="ir.ui.view">
         <field name="name">uom.uom.form.fe.cr</field>
         <field name="model">uom.uom</field>
-        <field name="inherit_id" ref="uom.uom_view_form"/>
+        <field name="inherit_id" eval="env.ref('uom.uom_view_form', raise_if_not_found=False)
+            or env.ref('uom.view_uom_form', raise_if_not_found=False)
+            or env.ref('product.product_uom_view_form', raise_if_not_found=False)
+            or env.ref('product.view_uom_form', raise_if_not_found=False)"/>
         <field name="arch" type="xml">
             <xpath expr="//sheet//group//field[@name='category_id']" position="after">
                 <field name="l10n_cr_code"/>
@@ -14,7 +17,10 @@
     <record id="view_uom_tree_inherit_fe_cr" model="ir.ui.view">
         <field name="name">uom.uom.list.fe.cr</field>
         <field name="model">uom.uom</field>
-        <field name="inherit_id" ref="uom.uom_view_tree"/>
+        <field name="inherit_id" eval="env.ref('uom.uom_view_tree', raise_if_not_found=False)
+            or env.ref('uom.view_uom_tree', raise_if_not_found=False)
+            or env.ref('product.product_uom_view_tree', raise_if_not_found=False)
+            or env.ref('product.view_uom_tree', raise_if_not_found=False)"/>
         <field name="arch" type="xml">
             <xpath expr="//tree//field[@name='name']" position="after">
                 <field name="l10n_cr_code"/>
@@ -25,7 +31,10 @@
     <record id="view_uom_search_inherit_fe_cr" model="ir.ui.view">
         <field name="name">uom.uom.view.search.fe.cr</field>
         <field name="model">uom.uom</field>
-        <field name="inherit_id" ref="uom.uom_view_search"/>
+        <field name="inherit_id" eval="env.ref('uom.uom_view_search', raise_if_not_found=False)
+            or env.ref('uom.view_uom_search', raise_if_not_found=False)
+            or env.ref('product.product_uom_view_search', raise_if_not_found=False)
+            or env.ref('product.view_uom_search', raise_if_not_found=False)"/>
         <field name="arch" type="xml">
             <xpath expr="//search//field[@name='name']" position="after">
                 <field name="l10n_cr_code"/>


### PR DESCRIPTION
## Summary
- make the UoM view inheritance robust to different xml ids provided by the core modules
- look up the base view dynamically so the localization installs even when product.uom manages the views

## Testing
- not run (configuration-specific)

------
https://chatgpt.com/codex/tasks/task_e_68db69009cfc8326b79f45a221590f89