### PR TITLE
Ensure Odoo 19 view compliance for CR EDI

### DIFF
--- a/l10n_cr_edi/models/electronic_document.py
+++ b/l10n_cr_edi/models/electronic_document.py
@@ -1,6 +1,6 @@
 import base64
 
-from odoo import api, fields, models, _
+from odoo import Command, _, api, fields, models
 
 
 class ElectronicDocument(models.Model):
@@ -30,8 +30,8 @@ class ElectronicDocument(models.Model):
         string="Estado",
         tracking=True,
     )
-    xml_comprobante = fields.Binary(string="XML Comprobante")
-    xml_respuesta = fields.Binary(string="XML Respuesta")
+    xml_comprobante = fields.Binary(string="XML Comprobante", attachment=True)
+    xml_respuesta = fields.Binary(string="XML Respuesta", attachment=True)
     xml_filename = fields.Char(string="Nombre del XML")
     message = fields.Text(string="Mensaje de Hacienda")
     sent_date = fields.Datetime(string="Fecha de envío")
@@ -52,5 +52,5 @@ class ElectronicDocument(models.Model):
                 "xml_filename": filename,
             }
         )
-        move.cr_document_ids = [(4, document.id)]
+        move.cr_document_ids = [Command.link(document.id)]
         return document

--- a/l10n_cr_edi/views/account_move_views.xml
+++ b/l10n_cr_edi/views/account_move_views.xml
@@ -15,15 +15,23 @@
                         <field name="cr_consecutive_number" readonly="1"/>
                         <field name="cr_activity_code"/>
                         <field name="cr_sale_condition"/>
-                        <field name="cr_credit_days" invisible="not show_cr_credit_days"/>
+                        <field name="cr_credit_days" attrs="{'invisible': [('show_cr_credit_days', '=', False)]}"/>
                         <field name="cr_payment_methods" placeholder="01,04"/>
                     </group>
                     <group>
                         <field name="cr_document_ids" readonly="1" widget="one2many_list"/>
                     </group>
                     <footer>
-                        <button name="action_generate_cr_xml" type="object" string="Generar XML Hacienda" class="btn-primary" invisible="not show_cr_xml_actions"/>
-                        <button name="action_send_cr_xml" type="object" string="Enviar XML a Hacienda" class="btn-secondary" invisible="not show_cr_xml_actions"/>
+                        <button name="action_generate_cr_xml"
+                                type="object"
+                                string="Generar XML Hacienda"
+                                class="btn-primary"
+                                attrs="{'invisible': [('show_cr_xml_actions', '=', False)]}"/>
+                        <button name="action_send_cr_xml"
+                                type="object"
+                                string="Enviar XML a Hacienda"
+                                class="btn-secondary"
+                                attrs="{'invisible': [('show_cr_xml_actions', '=', False)]}"/>
                     </footer>
                 </page>
             </xpath>


### PR DESCRIPTION
## Summary
- store Hacienda XML payloads as attachments and switch to Command API when linking documents
- update account move form buttons to use attrs-based invisibility compatible with Odoo 19

## Testing
- python -m compileall l10n_cr_edi fe_cr

------
https://chatgpt.com/codex/tasks/task_e_68dbca1a37008326be472a19967345ca