### PR TITLE
Fix FE CR invoice view modifiers for Odoo 17

### DIFF
--- a/l10n_cr_edi/views/account_move_views.xml
+++ b/l10n_cr_edi/views/account_move_views.xml
@@ -15,7 +15,7 @@
                         <field name="cr_consecutive_number" readonly="1"/>
                         <field name="cr_activity_code"/>
                         <field name="cr_sale_condition"/>
-                        <field name="cr_credit_days" attrs="{'invisible': [('show_cr_credit_days', '=', False)]}"/>
+                        <field name="cr_credit_days" invisible="not show_cr_credit_days"/>
                         <field name="cr_payment_methods" placeholder="01,04"/>
                     </group>
                     <group>
@@ -26,12 +26,12 @@
                                 type="object"
                                 string="Generar XML Hacienda"
                                 class="btn-primary"
-                                attrs="{'invisible': [('show_cr_xml_actions', '=', False)]}"/>
+                                invisible="not show_cr_xml_actions"/>
                         <button name="action_send_cr_xml"
                                 type="object"
                                 string="Enviar XML a Hacienda"
                                 class="btn-secondary"
-                                attrs="{'invisible': [('show_cr_xml_actions', '=', False)]}"/>
+                                invisible="not show_cr_xml_actions"/>
                     </footer>
                 </page>
             </xpath>


### PR DESCRIPTION
## Summary
- replace deprecated `attrs` modifiers with the new boolean expression syntax in the FE CR invoice view to match Odoo 17 requirements

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dbdbcaa1308326b52c697ffbb57e6c