### PR TITLE
Align invoice dataclasses with Odoo 19 optional fields

### DIFF
--- a/fe_cr/models.py
+++ b/fe_cr/models.py
@@ -124,13 +124,13 @@ class Discount:
 @dataclass(slots=True)
 class InvoiceLine:
     numero_linea: int
-    codigo: Optional[str]
     cantidad: Decimal
     unidad_medida: str
     detalle: str
     precio_unitario: Decimal
     monto_total: Decimal
     sub_total: Decimal
+    codigo: Optional[str] = None
     base_imponible: Optional[Decimal] = None
     impuesto: Optional[Tax] = None
     impuesto_neto: Optional[Decimal] = None
@@ -143,7 +143,7 @@ class InvoiceSummary:
     """Totales del comprobante según el esquema ``v4.4``."""
 
     moneda: str
-    tipo_cambio: Optional[Decimal]
+    tipo_cambio: Optional[Decimal] = None
     total_serv_gravados: Decimal = Decimal("0")
     total_serv_exentos: Decimal = Decimal("0")
     total_serv_exonerado: Decimal = Decimal("0")
@@ -184,12 +184,12 @@ class ElectronicInvoice:
     numero_consecutivo: str
     fecha_emision: datetime
     emisor: Emisor
-    receptor: Optional[Receptor]
     condicion_venta: SaleCondition
-    plazo_credito: Optional[str]
-    medios_pago: Sequence[PaymentMethod]
     detalle_servicio: Sequence[InvoiceLine]
     resumen: InvoiceSummary
+    receptor: Optional[Receptor] = None
+    plazo_credito: Optional[str] = None
+    medios_pago: Sequence[PaymentMethod] = field(default_factory=tuple)
     informacion_referencia: Sequence[ReferenceInformation] = field(default_factory=tuple)
     otros_cargos: Sequence[OtherCharge] = field(default_factory=tuple)
 

--- a/tests/test_models_fields.py
+++ b/tests/test_models_fields.py
@@ -1,0 +1,24 @@
+from dataclasses import fields
+from pathlib import Path
+import sys
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from fe_cr.models import ElectronicInvoice, InvoiceLine, InvoiceSummary
+
+
+def test_invoice_line_codigo_optional_default_none():
+    line_fields = {f.name: f for f in fields(InvoiceLine)}
+    assert line_fields["codigo"].default is None
+
+
+def test_invoice_summary_tipo_cambio_optional_default_none():
+    summary_fields = {f.name: f for f in fields(InvoiceSummary)}
+    assert summary_fields["tipo_cambio"].default is None
+
+
+def test_electronic_invoice_optional_defaults_align_with_odoo_structure():
+    invoice_fields = {f.name: f for f in fields(ElectronicInvoice)}
+    assert invoice_fields["receptor"].default is None
+    assert invoice_fields["plazo_credito"].default is None
+    assert invoice_fields["medios_pago"].default_factory() == tuple()


### PR DESCRIPTION
## Summary
- treat optional invoice dataclass attributes as optional defaults to match the Odoo 19 Costa Rican schema
- add regression tests that assert the optional field defaults stay aligned with the documented structure

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68dbdc5c59588326b7e43eff7b33ce6f