### PR TITLE
Adjust xpath for UoM view inheritance

### DIFF
--- a/l10n_cr_edi/views/uom_uom_views.xml
+++ b/l10n_cr_edi/views/uom_uom_views.xml
@@ -5,7 +5,7 @@
         <field name="model">uom.uom</field>
         <field name="inherit_id" ref="uom.product_uom_form_view"/>
         <field name="arch" type="xml">
-            <xpath expr="//sheet//group//field[@name='category_id']" position="after">
+            <xpath expr="//sheet//field[@name='uom_type']" position="after">
                 <field name="l10n_cr_code"/>
             </xpath>
         </field>


### PR DESCRIPTION
## Summary
- update the inherited UoM form view to insert the Costa Rican code after the UoM type field so the xpath matches the upstream structure

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dbf8d636988326a47924a1121cd565