### PR TITLE
Fix UoM view inheritance for l10n_cr_edi

### DIFF
--- a/l10n_cr_edi/views/uom_uom_views.xml
+++ b/l10n_cr_edi/views/uom_uom_views.xml
@@ -5,7 +5,7 @@
         <field name="model">uom.uom</field>
         <field name="inherit_id" ref="uom.product_uom_form_view"/>
         <field name="arch" type="xml">
-            <xpath expr="//sheet//field[@name='uom_type']" position="after">
+            <xpath expr="//sheet//field[@name='category_id']" position="after">
                 <field name="l10n_cr_code"/>
             </xpath>
         </field>


### PR DESCRIPTION
## Summary
- update the Units of Measure form view inheritance to place the Costa Rican code after the category field, matching the current core view structure

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dbfe4f6e28832698b6cec312e44682