### PR TITLE
Fix l10n_cr_edi UoM view xpath for category field

### DIFF
--- a/l10n_cr_edi/views/uom_uom_views.xml
+++ b/l10n_cr_edi/views/uom_uom_views.xml
@@ -5,7 +5,7 @@
         <field name="model">uom.uom</field>
         <field name="inherit_id" ref="uom.product_uom_form_view"/>
         <field name="arch" type="xml">
-            <xpath expr="//sheet//field[@name='category_id']" position="after">
+            <xpath expr="//field[@name='category_id']" position="after">
                 <field name="l10n_cr_code"/>
             </xpath>
         </field>


### PR DESCRIPTION
## Summary
- adjust the inherited UoM form view xpath to match the current base view structure

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dc27cd1ce88326b84ccefbcdefcfa5