### PR TITLE
Refactor Costa Rica EDI views for Odoo 19

### DIFF
--- a/l10n_cr_edi/views/account_move_views.xml
+++ b/l10n_cr_edi/views/account_move_views.xml
@@ -5,7 +5,18 @@
         <field name="model">account.move</field>
         <field name="inherit_id" ref="account.view_move_form"/>
         <field name="arch" type="xml">
-            <xpath expr="//sheet/notebook/page[@name='invoice_tab']" position="after">
+            <xpath expr="//form/header" position="inside">
+                <button name="action_generate_cr_xml"
+                        type="object"
+                        string="Generar XML Hacienda"
+                        class="oe_highlight"
+                        attrs="{'invisible': [('show_cr_xml_actions', '=', False)]}"/>
+                <button name="action_send_cr_xml"
+                        type="object"
+                        string="Enviar XML a Hacienda"
+                        attrs="{'invisible': [('show_cr_xml_actions', '=', False)]}"/>
+            </xpath>
+            <xpath expr="//sheet/notebook" position="inside">
                 <page name="fe_cr" string="Factura electrónica CR">
                     <field name="show_cr_credit_days" invisible="1"/>
                     <field name="show_cr_xml_actions" invisible="1"/>
@@ -15,24 +26,13 @@
                         <field name="cr_consecutive_number" readonly="1"/>
                         <field name="cr_activity_code"/>
                         <field name="cr_sale_condition"/>
-                        <field name="cr_credit_days" invisible="not show_cr_credit_days"/>
+                        <field name="cr_credit_days"
+                               attrs="{'invisible': [('show_cr_credit_days', '=', False)]}"/>
                         <field name="cr_payment_methods" placeholder="01,04"/>
                     </group>
                     <group>
-                        <field name="cr_document_ids" readonly="1" widget="one2many_list"/>
+                        <field name="cr_document_ids" readonly="1"/>
                     </group>
-                    <footer>
-                        <button name="action_generate_cr_xml"
-                                type="object"
-                                string="Generar XML Hacienda"
-                                class="btn-primary"
-                                invisible="not show_cr_xml_actions"/>
-                        <button name="action_send_cr_xml"
-                                type="object"
-                                string="Enviar XML a Hacienda"
-                                class="btn-secondary"
-                                invisible="not show_cr_xml_actions"/>
-                    </footer>
                 </page>
             </xpath>
         </field>

--- a/l10n_cr_edi/views/electronic_document_views.xml
+++ b/l10n_cr_edi/views/electronic_document_views.xml
@@ -40,7 +40,7 @@
                         </page>
                         <page string="Respuesta">
                             <field name="xml_respuesta" filename="xml_filename"/>
-                            <field name="message" widget="text" readonly="1"/>
+                            <field name="message" readonly="1"/>
                         </page>
                     </notebook>
                 </sheet>

--- a/l10n_cr_edi/views/menu_views.xml
+++ b/l10n_cr_edi/views/menu_views.xml
@@ -1,5 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <odoo>
-    <menuitem id="menu_fe_cr_root" name="Facturación Costa Rica" parent="account.menu_finance" sequence="50"/>
-    <menuitem id="menu_fe_cr_documents" name="Documentos electrónicos" parent="menu_fe_cr_root" action="action_fe_cr_documents" sequence="10"/>
+    <menuitem id="menu_fe_cr_root"
+              name="Facturación Costa Rica"
+              parent="account.menu_finance"
+              sequence="50"/>
+    <menuitem id="menu_fe_cr_documents"
+              name="Documentos electrónicos"
+              parent="menu_fe_cr_root"
+              action="action_fe_cr_documents"
+              sequence="10"/>
 </odoo>

--- a/l10n_cr_edi/views/res_company_views.xml
+++ b/l10n_cr_edi/views/res_company_views.xml
@@ -6,7 +6,7 @@
         <field name="inherit_id" ref="base.view_company_form"/>
         <field name="arch" type="xml">
             <xpath expr="//sheet/notebook" position="inside">
-                <page string="Factura electrónica CR">
+                <page name="fe_cr_company" string="Factura electrónica CR">
                     <group>
                         <group>
                             <field name="cr_identification_type"/>

--- a/l10n_cr_edi/views/res_partner_views.xml
+++ b/l10n_cr_edi/views/res_partner_views.xml
@@ -5,7 +5,7 @@
         <field name="model">res.partner</field>
         <field name="inherit_id" ref="base.view_partner_form"/>
         <field name="arch" type="xml">
-            <xpath expr="//page[@name='sales_purchases']" position="after">
+            <xpath expr="//sheet/notebook" position="inside">
                 <page name="fe_cr_partner" string="Factura electrónica CR">
                     <group>
                         <group>

--- a/l10n_cr_edi/views/uom_uom_views.xml
+++ b/l10n_cr_edi/views/uom_uom_views.xml
@@ -16,7 +16,7 @@
         <field name="model">uom.uom</field>
         <field name="inherit_id" ref="uom.uom_view_tree"/>
         <field name="arch" type="xml">
-            <xpath expr="//tree//field[@name='name']" position="after">
+            <xpath expr="//list//field[@name='name']" position="after">
                 <field name="l10n_cr_code"/>
             </xpath>
         </field>


### PR DESCRIPTION
## Summary
- update inherited account move view to add XML actions in the header and rely on generic notebook hooks compatible with Odoo 19
- adjust company, partner, and menu XML definitions to avoid outdated xpath targets and improve formatting
- refresh auxiliary views to drop deprecated attributes and use list view selectors supported in newer versions

## Testing
- python -m compileall l10n_cr_edi

------
https://chatgpt.com/codex/tasks/task_e_68dc67bde1048326953c8c60a3ef2047