### PR TITLE
Adjust UoM view inheritance for new base layout

### DIFF
--- a/l10n_cr_edi/views/uom_uom_views.xml
+++ b/l10n_cr_edi/views/uom_uom_views.xml
@@ -5,7 +5,9 @@
         <field name="model">uom.uom</field>
         <field name="inherit_id" ref="uom.product_uom_form_view"/>
         <field name="arch" type="xml">
-            <xpath expr="//field[@name='category_id']" position="after">
+            <!-- The base view for uom.uom no longer exposes the category field,
+                 so we attach the Costa Rican code after the unit type instead. -->
+            <xpath expr="//field[@name='uom_type']" position="after">
                 <field name="l10n_cr_code"/>
             </xpath>
         </field>


### PR DESCRIPTION
## Summary
- update the inherited UoM form view so the Costa Rican code field is inserted after `uom_type`
- add a comment explaining why the XPath target changed

## Testing
- not run (UI-only change)


------
https://chatgpt.com/codex/tasks/task_e_68dcbd7a77588326abab2343f40e7ae7