### PR TITLE
Handle renamed UoM type field in Costa Rican view

### DIFF
--- a/l10n_cr_edi/views/uom_uom_views.xml
+++ b/l10n_cr_edi/views/uom_uom_views.xml
@@ -7,7 +7,7 @@
         <field name="arch" type="xml">
             <!-- The base view for uom.uom no longer exposes the category field,
                  so we attach the Costa Rican code after the unit type instead. -->
-            <xpath expr="//field[@name='uom_type']" position="after">
+            <xpath expr="//field[@name='uom_type'] | //field[@name='measure_type']" position="after">
                 <field name="l10n_cr_code"/>
             </xpath>
         </field>


### PR DESCRIPTION
## Summary
- make the uom.uom Costa Rican form view insert the code after either `uom_type` or `measure_type`

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dcdb1673f08326bab3d40d3b597e37