### PR TITLE
Adjust UoM CR code field placement

### DIFF
--- a/l10n_cr_edi/models/uom_uom.py
+++ b/l10n_cr_edi/models/uom_uom.py
@@ -5,6 +5,6 @@ class UomUom(models.Model):
     _inherit = "uom.uom"
 
     l10n_cr_code = fields.Char(
-        string="Código unidad CR",
+        string="Código EDI (CR)",
         help="Código de unidad de medida según el catálogo oficial de Hacienda.",
     )

--- a/l10n_cr_edi/views/uom_uom_views.xml
+++ b/l10n_cr_edi/views/uom_uom_views.xml
@@ -4,11 +4,11 @@
         <field name="name">uom.uom.form.fe.cr</field>
         <field name="model">uom.uom</field>
         <field name="inherit_id" ref="uom.product_uom_form_view"/>
-        <field name="priority" eval="20"/>
+        <field name="priority" eval="90"/>
         <field name="arch" type="xml">
-            <field name="category_id" position="after">
+            <xpath expr="(//form//field[@name='category_id'] | //form//field[@name='name'])[1]" position="after">
                 <field name="l10n_cr_code" optional="hide"/>
-            </field>
+            </xpath>
         </field>
     </record>
 


### PR DESCRIPTION
## Summary
- align the localized UoM field label with the expected Código EDI (CR) wording
- update the UoM form inheritance to insert the field after either category or name so it always renders

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68de1e82adb883269908c52fec8def1a