### PR TITLE
Fix l10n_cr_code column in UoM tree view

### DIFF
--- a/l10n_cr_edi/views/uom_uom_views.xml
+++ b/l10n_cr_edi/views/uom_uom_views.xml
@@ -15,9 +15,10 @@
     <record id="view_uom_tree_inherit_fe_cr" model="ir.ui.view">
         <field name="name">uom.uom.list.fe.cr</field>
         <field name="model">uom.uom</field>
-        <field name="inherit_id" ref="uom.uom_view_tree"/>
+        <field name="inherit_id" ref="uom.product_uom_tree_view"/>
+        <field name="priority" eval="90"/>
         <field name="arch" type="xml">
-            <xpath expr="//list//field[@name='name']" position="after">
+            <xpath expr="//tree//field[@name='name']" position="after">
                 <field name="l10n_cr_code"/>
             </xpath>
         </field>


### PR DESCRIPTION
## Summary
- update the UoM list view inheritance to extend the correct tree view
- ensure the l10n_cr_code column is inserted after the name column via a tree xpath

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68de2a5419648326a5b418c7d3f03895